### PR TITLE
Upgrade stack resolvers

### DIFF
--- a/ghc-8.2.yaml
+++ b/ghc-8.2.yaml
@@ -1,4 +1,4 @@
-resolver: lts-11.19
+resolver: lts-11.22
 
 packages:
   - crdt

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-12.0
+resolver: lts-12.26
 
 packages:
   - crdt


### PR DESCRIPTION
`stack.yaml` uses GHC 8.4.4 now instead of GHC 8.4.3.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cblp/crdt/27)
<!-- Reviewable:end -->
