### PR TITLE
Add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # CRDT [![Hackage version](https://img.shields.io/hackage/v/crdt.svg?label=Hackage)](https://hackage.haskell.org/package/crdt) <!-- [![Stackage version](https://www.stackage.org/package/crdt/badge/lts?label=Stackage)](https://www.stackage.org/package/crdt) --> [![Linux Build Status](https://img.shields.io/travis/cblp/crdt.svg?label=Linux%20build)](https://travis-ci.org/cblp/crdt) <!-- [![Windows Build Status](https://img.shields.io/appveyor/ci/cblp/crdt.svg?label=Windows%20build)](https://ci.appveyor.com/project/cblp/crdt) -->
 
 Definitions of CmRDT and CvRDT. Implementations for some classic CRDTs.
+
+## DEPRECATION NOTICE
+
+This package is for reference purposes only. If you plan on using CRDTs in a
+real-world application, take a look at the
+[ron](https://github.com/ff-notes/ron) package.


### PR DESCRIPTION
Following up on #27 I think it would help to direct people to the ron package in the README.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cblp/crdt/28)
<!-- Reviewable:end -->
